### PR TITLE
BUGFIX: Replaced 'find ./' with 'find .' to fix for MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 <img src="https://cdn.rawgit.com/oh-my-fish/oh-my-fish/e4f1c2e0219a17e2c748b824004c8d0b38055c16/docs/logo.svg" align="left" width="144px" height="144px"/>
 
 #### git-refresh
+
+This is a clone of avimehenwal/git-fish, which fixes an issue with the 'find' command when run on MacOS with the latest fish (V3.5.1).
+
 > A plugin for [Oh My Fish][omf-link].
 
 [![MIT License](https://img.shields.io/badge/license-MIT-007EC7.svg?style=flat-square)](/LICENSE)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Hail Automation! :)
 ## Install
 
 ```fish
-$ omf install git-refresh
+$ fisher install PJC-64/git-refresh
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This is a clone of avimehenwal/git-refresh, which fixes an issue with the 'find'
 
 [![MIT License](https://img.shields.io/badge/license-MIT-007EC7.svg?style=flat-square)](/LICENSE)
 [![Fish Shell Version](https://img.shields.io/badge/fish-v2.2.0-007EC7.svg?style=flat-square)](https://fishshell.com)
-[![Oh My Fish Framework](https://img.shields.io/badge/Oh%20My%20Fish-Framework-007EC7.svg?style=flat-square)](https://www.github.com/oh-my-fish/oh-my-fish)
+
+- NOTE: See Install for installation method via fisher.  This version is NOT available directly via OMF.
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 #### git-refresh
 
-This is a clone of avimehenwal/git-refresh, which fixes an issue with the 'find' command when run on MacOS with the latest fish (V3.5.1).
+This is a fork of avimehenwal/git-refresh, which fixes an issue with the 'find' command when run on MacOS with the latest fish (V3.5.1).
 
 > A plugin for [Oh My Fish][omf-link].
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 #### git-refresh
 
-This is a clone of avimehenwal/git-fish, which fixes an issue with the 'find' command when run on MacOS with the latest fish (V3.5.1).
+This is a clone of avimehenwal/git-refresh, which fixes an issue with the 'find' command when run on MacOS with the latest fish (V3.5.1).
 
 > A plugin for [Oh My Fish][omf-link].
 

--- a/init.fish
+++ b/init.fish
@@ -7,7 +7,7 @@
 
 function git-refresh --on-variable PWD \
   --description "git pull automatically wherever inside a git repository"
-    set --local hasGit (find ./ -maxdepth 1 -type d -name .git -print)
+    set --local hasGit (find . -maxdepth 1 -type d -name .git -print)
     if test "$hasGit" = "./.git"
         echo -e "\e[1m(git-refresh) - GIT repo detected\e[0m"
         git pull --all --verbose


### PR DESCRIPTION
On MacOS, 'find ./' doesn't produce './.git' as the output.  Changing this to 'find .' fixes this, and still works on Linux (Tested on Ubuntu).